### PR TITLE
Add verify option to UrlRequest

### DIFF
--- a/kivy/network/urlrequest.py
+++ b/kivy/network/urlrequest.py
@@ -17,7 +17,7 @@ The syntax to create a request::
     from kivy.network.urlrequest import UrlRequest
     req = UrlRequest(url, on_success, on_redirect, on_failure, on_error,
                      on_progress, req_body, req_headers, chunk_size,
-                     timeout, method, decode, debug, file_path)
+                     timeout, method, decode, debug, file_path, verify)
 
 
 Only the first argument is mandatory: the rest are optional.
@@ -144,6 +144,8 @@ class UrlRequest(Thread):
         `ca_file`: str, defaults to None
             Indicates a SSL CA certificate file path to validate HTTPS
             certificates against
+        `verify`: bool, defaults to True
+            Toggles SSL CA certificate verification
 
     .. versionchanged:: 1.8.0
 
@@ -158,7 +160,7 @@ class UrlRequest(Thread):
                  on_failure=None, on_error=None, on_progress=None,
                  req_body=None, req_headers=None, chunk_size=8192,
                  timeout=None, method=None, decode=True, debug=False,
-                 file_path=None, ca_file=None):
+                 file_path=None, ca_file=None, verify=True):
         super(UrlRequest, self).__init__()
         self._queue = deque()
         self._trigger_result = Clock.create_trigger(self._dispatch_result, 0)
@@ -181,6 +183,7 @@ class UrlRequest(Thread):
         self._timeout = timeout
         self._method = method
         self.ca_file = ca_file
+        self.verify = verify
 
         #: Url of the request
         self.url = url
@@ -231,6 +234,7 @@ class UrlRequest(Thread):
         timeout = self._timeout
         file_path = self.file_path
         ca_file = self.ca_file
+        verify = self.verify
 
         if self._debug:
             Logger.debug('UrlRequest: {0} Fetch url <{1}>'.format(
@@ -261,6 +265,12 @@ class UrlRequest(Thread):
         if ca_file is not None and hasattr(ssl, 'create_default_context'):
             ctx = ssl.create_default_context(cafile=ca_file)
             ctx.verify_mode = ssl.CERT_REQUIRED
+            args['context'] = ctx
+
+        if not verify:
+            ctx = ssl.create_default_context()
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
             args['context'] = ctx
 
         req = cls(host, port, **args)
@@ -524,3 +534,4 @@ if __name__ == '__main__':
 
     print('result =', req.result)
     print('error =', req.error)
+    


### PR DESCRIPTION
This PR overrides the last one I made.
After testing the last PR I found a problem where you couldn't set ssl.CERT_NONE if the check_hostname variable of the context wasn't set to False.

This PR fixes that issue and makes it so that if verify is set to False it will override the context created when ca_file is not None and set a context where check_hostname = False and verify_mode = ssl.CERT_NONE bypassing the ssl verification even if the user set a ssl certificate with ca_file.

Note: the verify option also disables verification if ca_file is still None.
